### PR TITLE
Remove sandbox test credentials from walkthrough

### DIFF
--- a/public/js/walkthrough.js
+++ b/public/js/walkthrough.js
@@ -240,20 +240,6 @@
       <p class="step-description">
         Click <strong>"Verify with ID.me"</strong> in the mock browser to start a real ${escapeHtml(cfg.label)} authentication flow. A popup window will open with the ID.me login page.
       </p>
-      <p class="step-description">
-        Use the sandbox test credentials below to complete the verification.
-      </p>
-      <div class="credentials-box">
-        <div class="credentials-box-title">Sandbox Test Credentials</div>
-        <div class="credentials-row">
-          <span class="credentials-label">Email</span>
-          <span class="credentials-value">test@id.me</span>
-        </div>
-        <div class="credentials-row">
-          <span class="credentials-label">Password</span>
-          <span class="credentials-value">P@ssword1!</span>
-        </div>
-      </div>
       ${samlNotice}
       <div class="api-inspector" style="margin-top: 24px;">
         <div class="api-inspector-tabs" id="step6Tabs">

--- a/views/walkthrough.ejs
+++ b/views/walkthrough.ejs
@@ -450,7 +450,7 @@
                   <h4>Sandbox vs. Production</h4>
                   <p>The sandbox environment (<code>api.idmelabs.com</code>) mirrors production behavior but uses test data. No real identity documents are verified. This is where you develop and test your integration before going live.</p>
                   <ul>
-                    <li><strong>Sandbox</strong> &mdash; Test credentials work (e.g. <code>test@id.me</code>), no real verification occurs, separate client credentials from production.</li>
+                    <li><strong>Sandbox</strong> &mdash; No real verification occurs, separate client credentials from production.</li>
                     <li><strong>Production</strong> &mdash; Real users, real document verification, real identity data. Uses <code>api.id.me</code>.</li>
                   </ul>
                   <h4>Client Credential Security</h4>


### PR DESCRIPTION
## Summary
- Removes hardcoded test email (`test@id.me`) and password (`P@ssword1!`) from step 6 live demo page
- Removes `test@id.me` reference from the sandbox vs. production learn-more section

## Test plan
- [ ] Visit walkthrough step 6 — credentials box should no longer appear
- [ ] Check "Learn More: Environment & Configuration Best Practices" — sandbox bullet should not reference test credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)